### PR TITLE
🛡️ Sentinel: Fix insecure postMessage wildcard in OAuth2 redirects

### DIFF
--- a/packages/react-ui/src/app/routes/redirect.tsx
+++ b/packages/react-ui/src/app/routes/redirect.tsx
@@ -13,7 +13,7 @@ const RedirectPage: React.FC = React.memo(() => {
         {
           code: code,
         },
-        '*',
+        window.location.origin,
       );
     }
   }, [location.search]);

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -74,9 +74,10 @@ function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
 function getCode(redirectUrl: string): Promise<string> {
   return new Promise<string>((resolve) => {
     window.addEventListener('message', function handler(event) {
+      const expectedOrigin = new URL(redirectUrl).origin;
       if (
         redirectUrl &&
-        redirectUrl.startsWith(event.origin) &&
+        event.origin === expectedOrigin &&
         event.data['code']
       ) {
         resolve(decodeURIComponent(event.data.code));

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -82,6 +82,7 @@ import { pieceMetadataServiceHooks } from './pieces/piece-metadata-service/hooks
 import { pieceSyncService } from './pieces/piece-sync-service'
 import { platformModule } from './platform/platform.module'
 import { platformService } from './platform/platform.service'
+import { platformUtils } from './platform/platform.utils'
 import { projectHooks } from './project/project-hooks'
 import { projectModule } from './project/project-module'
 import { storeEntryModule } from './store-entry/store-entry.module'
@@ -250,12 +251,16 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
                 return reply.send('The code is missing in url')
             }
             else {
+                const platformId = await platformUtils.getPlatformIdForRequest(request)
+                const targetOrigin = await domainHelper.getPublicUrl({
+                    platformId,
+                })
                 return reply
                     .type('text/html')
                     .send(
-                        `<script>if(window.opener){window.opener.postMessage({ 'code': '${encodeURIComponent(
-                            params.code,
-                        )}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`,
+                        `<script>if(window.opener){window.opener.postMessage(${JSON.stringify({
+                            code: params.code,
+                        })}, ${JSON.stringify(targetOrigin)})}</script> <html>Redirect successfully, this window should close now</html>`,
                     )
             }
         },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Use of wildcard ('*') as target origin in window.postMessage during OAuth2 redirects.
🎯 Impact: Sensitive OAuth2 authorization codes could be leaked to malicious origins if a user is tricked into opening the redirect page from an untrusted site.
🔧 Fix:
- Restricted postMessage target origin to the actual application origin in both server-side and client-side redirect handlers.
- Hardened the frontend message listener to perform strict origin verification.
- Improved server-side payload serialization using JSON.stringify.
✅ Verification:
- Verified code changes manually for correctness and security best practices.
- Ran eslint on modified files.

---
*PR created automatically by Jules for task [13943745947564606606](https://jules.google.com/task/13943745947564606606) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth2 authentication security by enforcing exact origin validation instead of partial-origin matches, preventing unauthorized cross-origin access.
  * Corrected redirect success message text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->