### PR TITLE
🛡️ Sentinel: [HIGH] Harden OAuth postMessage security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-01 - [OAuth postMessage Origin Hardening]
+**Vulnerability:** Insecure use of `postMessage` with wildcard origin (`'*'`) and weak origin validation using `startsWith`.
+**Learning:** OAuth redirect handlers often use `window.opener.postMessage` to send authorization codes back to the main application window. Using `'*'` allows any site that can open or reference the redirect window to intercept these codes. Furthermore, using `startsWith` for origin validation is bypassable (e.g., `https://trusted.com.attacker.com` starts with `https://trusted.com`).
+**Prevention:** Always use a specific target origin in `postMessage` calls. For origin validation in message listeners, use strict equality with a derived origin from a trusted URL (e.g., `new URL(trustedUrl).origin === event.origin`). Always add safety checks for URL parsing.

--- a/packages/react-ui/src/app/routes/redirect.tsx
+++ b/packages/react-ui/src/app/routes/redirect.tsx
@@ -13,7 +13,7 @@ const RedirectPage: React.FC = React.memo(() => {
         {
           code: code,
         },
-        '*',
+        window.location.origin,
       );
     }
   }, [location.search]);

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -71,12 +71,20 @@ function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
   return url.toString();
 }
 
-function getCode(redirectUrl: string): Promise<string> {
+function getCode(redirectUrl: string | undefined): Promise<string> {
   return new Promise<string>((resolve) => {
     window.addEventListener('message', function handler(event) {
+      if (!redirectUrl) {
+        return;
+      }
+      let origin;
+      try {
+        origin = new URL(redirectUrl).origin;
+      } catch (e) {
+        return;
+      }
       if (
-        redirectUrl &&
-        redirectUrl.startsWith(event.origin) &&
+        origin === event.origin &&
         event.data['code']
       ) {
         resolve(decodeURIComponent(event.data.code));

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -250,12 +250,13 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
                 return reply.send('The code is missing in url')
             }
             else {
+                const origin = await domainHelper.getPublicUrl({})
                 return reply
                     .type('text/html')
                     .send(
                         `<script>if(window.opener){window.opener.postMessage({ 'code': '${encodeURIComponent(
                             params.code,
-                        )}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`,
+                        )}' }, '${origin}')}</script> <html>Redirect succuesfully, this window should close now</html>`,
                     )
             }
         },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Insecure use of `postMessage` with wildcard origin (`'*'`) and weak origin validation using `startsWith`.
🎯 Impact: Sensitive OAuth codes could be intercepted by malicious origins if they are able to open the redirect window or if the origin validation is bypassed.
🔧 Fix:
- Restricted `postMessage` target origins to trusted frontend URLs using `domainHelper.getPublicUrl` on the server and `window.location.origin` on the client.
- Hardened origin verification in the message listener by using strict equality of the derived `origin` instead of `startsWith`.
- Added robust URL parsing and safety checks to prevent crashes.
✅ Verification: Targeted linting of modified files and manual code review. Logic ensures defense-in-depth for sensitive data transmission between windows.

---
*PR created automatically by Jules for task [11497284544736004468](https://jules.google.com/task/11497284544736004468) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened OAuth postMessage handling by restricting and strictly validating the target origin.
  * Improved popup cleanup and removal of event listeners after OAuth redirects complete.
  * Added safer handling for missing or invalid redirect URLs and related edge-case errors.

* **Documentation**
  * Added a security note documenting the origin hardening guidance and mitigation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->