### PR TITLE
🛡️ Sentinel: Fix insecure postMessage target origins in OAuth2 flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Secure postMessage origins in OAuth2 flow]
+**Vulnerability:** Use of `*` wildcard as target origin in `window.postMessage` during OAuth2 redirection, which could leak authorization codes to malicious windows.
+**Learning:** The codebase has multiple places (frontend and backend) where `postMessage` is used to communicate the OAuth code back to the opener.
+**Prevention:** Use `window.location.origin` on the client and `domainHelper.getPublicUrl` on the server to resolve the trusted frontend origin. Always extract only the origin (scheme + host + port) using `new URL(url).origin` to ensure strict matching by the browser.

--- a/packages/react-ui/src/app/routes/redirect.tsx
+++ b/packages/react-ui/src/app/routes/redirect.tsx
@@ -13,7 +13,7 @@ const RedirectPage: React.FC = React.memo(() => {
         {
           code: code,
         },
-        '*',
+        window.location.origin,
       );
     }
   }, [location.search]);

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -74,9 +74,10 @@ function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
 function getCode(redirectUrl: string): Promise<string> {
   return new Promise<string>((resolve) => {
     window.addEventListener('message', function handler(event) {
+      const expectedOrigin = new URL(redirectUrl).origin;
       if (
         redirectUrl &&
-        redirectUrl.startsWith(event.origin) &&
+        event.origin === expectedOrigin &&
         event.data['code']
       ) {
         resolve(decodeURIComponent(event.data.code));

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -250,12 +250,14 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
                 return reply.send('The code is missing in url')
             }
             else {
+                const frontendUrl = await domainHelper.getPublicUrl({ platformId: null })
+                const frontendOrigin = new URL(frontendUrl).origin
                 return reply
                     .type('text/html')
                     .send(
                         `<script>if(window.opener){window.opener.postMessage({ 'code': '${encodeURIComponent(
                             params.code,
-                        )}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`,
+                        )}' }, '${frontendOrigin}')}</script> <html>Redirect succuesfully, this window should close now</html>`,
                     )
             }
         },


### PR DESCRIPTION
This PR addresses a security vulnerability where sensitive OAuth2 authorization codes were being broadcasted using `window.postMessage` with a wildcard (`*`) target origin.

### Changes:
1.  **Strict Target Origins:** Replaced `*` with the actual frontend origin in both the React frontend (`redirect.tsx`) and the Fastify backend (`app.ts`). The backend now uses `domainHelper.getPublicUrl` to resolve the correct frontend origin dynamically.
2.  **Strict Origin Verification:** Updated the message listener in `oauth2-utils.ts` to use strict equality (`===`) for origin verification instead of a prefix match (`startsWith`), preventing potential bypasses from malicious subdomains or similar-looking origins.

### Impact:
This fix prevents malicious third-party websites from intercepting OAuth2 authorization codes if they manage to open or be opened by the Activepieces window during the authentication flow.

### Verification:
- Manual code review confirmed the logic follows security best practices for cross-window communication.
- Linting passed for the affected files.
- Verified that `domainHelper` is the standard way to resolve the frontend URL in this monorepo.

---
*PR created automatically by Jules for task [3982164033771812107](https://jules.google.com/task/3982164033771812107) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened OAuth2 redirect and inter-window messaging by restricting accepted origins to specific trusted origins rather than wildcard targets.

* **Documentation**
  * Added a security note documenting secure origin handling for postMessage in the OAuth2 flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->