### PR TITLE
🛡️ Sentinel: Fix insecure postMessage origin in OAuth redirects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [HIGH] Insecure postMessage Origin in OAuth Redirects
+**Vulnerability:** Use of wildcard origin (`'*'`) in `window.postMessage` calls within OAuth redirect handlers (both server-side generated HTML and client-side React routes).
+**Learning:** Wildcard origins in `postMessage` allow any site that can open or iframe the redirect page to intercept sensitive information, such as OAuth authorization codes. In a multi-tenant environment (like Activepieces with custom domains), the expected origin must be resolved dynamically.
+**Prevention:** Always restrict the `targetOrigin` to a trusted value. For client-side redirects, use `window.location.origin` if the communication is same-origin. For server-side generated redirects, use platform-aware URL resolvers (e.g., `domainHelper.getPublicUrl`) to determine the correct frontend origin.

--- a/packages/react-ui/src/app/routes/redirect.tsx
+++ b/packages/react-ui/src/app/routes/redirect.tsx
@@ -13,7 +13,7 @@ const RedirectPage: React.FC = React.memo(() => {
         {
           code: code,
         },
-        '*',
+        window.location.origin,
       );
     }
   }, [location.search]);

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -73,10 +73,11 @@ function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
 
 function getCode(redirectUrl: string): Promise<string> {
   return new Promise<string>((resolve) => {
+    const expectedOrigin = redirectUrl ? new URL(redirectUrl).origin : null;
     window.addEventListener('message', function handler(event) {
       if (
         redirectUrl &&
-        redirectUrl.startsWith(event.origin) &&
+        event.origin === expectedOrigin &&
         event.data['code']
       ) {
         resolve(decodeURIComponent(event.data.code));

--- a/packages/react-ui/src/lib/oauth2-utils.ts
+++ b/packages/react-ui/src/lib/oauth2-utils.ts
@@ -73,10 +73,17 @@ function constructUrl(params: OAuth2PopupParams, pckeChallenge: string) {
 
 function getCode(redirectUrl: string): Promise<string> {
   return new Promise<string>((resolve) => {
-    const expectedOrigin = redirectUrl ? new URL(redirectUrl).origin : null;
+    let expectedOrigin: string | null = null;
+    try {
+      expectedOrigin = redirectUrl ? new URL(redirectUrl).origin : null;
+    } catch (e) {
+      console.error('Invalid redirectUrl', redirectUrl, e);
+    }
+
     window.addEventListener('message', function handler(event) {
       if (
         redirectUrl &&
+        expectedOrigin &&
         event.origin === expectedOrigin &&
         event.data['code']
       ) {

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -82,6 +82,7 @@ import { pieceMetadataServiceHooks } from './pieces/piece-metadata-service/hooks
 import { pieceSyncService } from './pieces/piece-sync-service'
 import { platformModule } from './platform/platform.module'
 import { platformService } from './platform/platform.service'
+import { platformUtils } from './platform/platform.utils'
 import { projectHooks } from './project/project-hooks'
 import { projectModule } from './project/project-module'
 import { storeEntryModule } from './store-entry/store-entry.module'

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -250,12 +250,15 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
                 return reply.send('The code is missing in url')
             }
             else {
+                const platformId = await platformUtils.getPlatformIdForRequest(request)
+                const frontendUrl = await domainHelper.getPublicUrl({ platformId })
+                const targetOrigin = new URL(frontendUrl).origin
                 return reply
                     .type('text/html')
                     .send(
                         `<script>if(window.opener){window.opener.postMessage({ 'code': '${encodeURIComponent(
                             params.code,
-                        )}' },'*')}</script> <html>Redirect succuesfully, this window should close now</html>`,
+                        )}' },'${targetOrigin}')}</script> <html>Redirect successfully, this window should close now</html>`,
                     )
             }
         },


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure postMessage origin in OAuth redirects

Restricted the target origin of `window.postMessage` in both server-side and client-side OAuth redirect handlers. Using a wildcard origin (`'*'`) is insecure as it allows sensitive authorization codes to be intercepted by malicious origins.

- In `packages/server/api/src/app/app.ts`, the `/redirect` route now resolves the platform-specific frontend origin.
- In `packages/react-ui/src/app/routes/redirect.tsx`, the `targetOrigin` is restricted to `window.location.origin`.
- Updated `.jules/sentinel.md` with details of this vulnerability and prevention strategy.

---
*PR created automatically by Jules for task [843941654461830414](https://jules.google.com/task/843941654461830414) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened origin validation in OAuth redirect flows, restricting postMessage targets to specific origins and improving security.
  * Fixed typo in the redirect success message.

* **Documentation**
  * Added security guidance documenting the vulnerability, recommending dynamic origin resolution for multi-tenant setups and safer targetOrigin handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->