### PR TITLE
🛡️ Sentinel: Fix JWT token leakage in error parameters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-17 - Sensitive Token Leakage in Error Responses
+**Vulnerability:** The `INVALID_OR_EXPIRED_JWT_TOKEN` error was including the full JWT token in its `params`, which the global `errorHandler` then echoed back to the client.
+**Learning:** Even invalid or expired tokens can reveal sensitive information about the system's token structure or authentication mechanisms. Global error handlers that serialize all error parameters can unintentionally leak sensitive data.
+**Prevention:** Sanitize error parameters at the source or in the global error handler. Ensure that error parameter types in `activepieces-error.ts` do not include fields that might contain secrets or tokens.

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<


### PR DESCRIPTION
This PR addresses a security enhancement by preventing the disclosure of JWT tokens (even if invalid or expired) in error responses.

### 🚨 Severity: MEDIUM (Security Enhancement)

### 💡 Vulnerability
The `INVALID_OR_EXPIRED_JWT_TOKEN` error was including the full JWT token in its `params` object. The application's global `errorHandler` in `packages/server/api/src/app/helper/error-handler.ts` serializes these parameters directly into the response body.

### 🎯 Impact
Echoing back bearer tokens, even invalid ones, can provide an attacker with insights into the expected token format, structure, or content. It also leads to unnecessary exposure of tokens in logs (server-side and client-side) and through interception.

### 🔧 Fix
1.  **Shared Types:** Modified `packages/shared/src/lib/common/activepieces-error.ts` to update the `InvalidJwtTokenErrorParams` type, removing the `token` field and replacing it with an empty `Record<string, never>`.
2.  **Service Logic:** Updated `packages/server/api/src/app/ee/connection-keys/connection-key.service.ts` to stop passing the token when throwing the `INVALID_OR_EXPIRED_JWT_TOKEN` error.
3.  **Sentinel Journal:** Documented this vulnerability pattern in `.jules/sentinel.md` to prevent future occurrences.

### ✅ Verification
-   Verified code changes through manual inspection to ensure no sensitive fields are passed to `ActivepiecesError`.
-   Ran `pnpm nx test shared` to ensure no regressions in core error handling types.
-   Confirmed via `git status` that no unrelated artifacts (like `pnpm-lock.yaml` or build logs) are included in the submission.


---
*PR created automatically by Jules for task [9029737308741381011](https://jules.google.com/task/9029737308741381011) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a security vulnerability where authentication tokens were inadvertently exposed in error messages. Error responses no longer include sensitive token information.

* **Documentation**
  * Added security documentation outlining the token exposure issue and prevention strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->