### PR TITLE
🛡️ Sentinel: Fix sensitive data leakage in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Exposure of Sensitive Data in Error Parameters
+**Vulnerability:** Sensitive data (JWT tokens and License Keys) were included in the `params` field of `ActivepiecesError` objects, which are directly serialized and sent to the client by the global error handler in `packages/server/api/src/app/helper/error-handler.ts`.
+**Learning:** The global error handler's behavior of exposing the entire `params` object means that any data placed there is effectively public if the error is triggered. This creates a leak if `params` is used to provide context for debugging that includes secrets.
+**Prevention:** Strictly define error parameter types in `packages/shared/src/lib/common/activepieces-error.ts` to only include non-sensitive fields. Use `Record<string, never>` or empty objects for errors related to sensitive credentials.

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
@@ -40,9 +40,7 @@ export const licenseKeysController: FastifyPluginAsyncTypebox = async (app) => {
         if (isNil(key)) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_LICENSE_KEY,
-                params: {
-                    key: licenseKey,
-                },
+                params: {},
             })
         }
         await platformService.update({

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<
@@ -405,9 +403,7 @@ ErrorCode.EXISTING_ALERT_CHANNEL,
 
 export type InvalidOtpParams = BaseErrorParams<ErrorCode.INVALID_OTP, Record<string, never>>
 
-export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, {
-    key: string
-}>  
+export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, Record<string, never>>
 
 export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREADY_HAS_ACTIVATION_KEY, {
     email: string


### PR DESCRIPTION
This PR addresses a security vulnerability where sensitive information, specifically JWT tokens and license keys, was being included in error responses sent to the client.

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Exposure of Sensitive Data in Error Messages
### 🎯 Impact: 
Invalid or expired JWT tokens and license keys were included in the `params` field of `ActivepiecesError` objects. These objects are serialized and sent to the client by the global error handler in the backend. While the tokens/keys might be invalid or expired, leaking them still provides unnecessary information to potential attackers and can lead to sensitive data being recorded in client-side logs or intercepted.

### 🔧 Fix:
- Modified `packages/shared/src/lib/common/activepieces-error.ts` to change the parameter types for `INVALID_OR_EXPIRED_JWT_TOKEN` and `INVALID_LICENSE_KEY` to `Record<string, never>`.
- Updated call sites in `packages/server/api/src/app/ee/connection-keys/connection-key.service.ts` and `packages/server/api/src/app/ee/license-keys/license-keys-controller.ts` to stop passing the sensitive data to the error constructor.

### ✅ Verification:
- Manual code inspection confirms no sensitive data is passed to these error types.
- Ran `nx lint` on the affected packages to ensure type safety.
- Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8744681762830886235](https://jules.google.com/task/8744681762830886235) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling to remove sensitive authentication and license information from client-facing error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->