### PR TITLE
🛡️ Sentinel: Fix sensitive data leakage in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - [Sensitive Data Leakage in Error Responses]
+**Vulnerability:** Sensitive data like JWT tokens and license keys were being leaked to the client through the 'params' field of ActivepiecesError.
+**Learning:** The global error handler in 'packages/server/api/src/app/helper/error-handler.ts' serializes 'error.error.params' directly to the response body.
+**Prevention:** Always use 'Record<string, never>' or similar non-sensitive types for error parameters that might contain secrets, and ensure they are sanitized before being passed to an error constructor.

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
@@ -40,9 +40,7 @@ export const licenseKeysController: FastifyPluginAsyncTypebox = async (app) => {
         if (isNil(key)) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_LICENSE_KEY,
-                params: {
-                    key: licenseKey,
-                },
+                params: {},
             })
         }
         await platformService.update({

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<
@@ -405,9 +403,7 @@ ErrorCode.EXISTING_ALERT_CHANNEL,
 
 export type InvalidOtpParams = BaseErrorParams<ErrorCode.INVALID_OTP, Record<string, never>>
 
-export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, {
-    key: string
-}>  
+export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, Record<string, never>>
 
 export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREADY_HAS_ACTIVATION_KEY, {
     email: string


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive data (JWT tokens and license keys) was included in `ActivepiecesError` parameters, which are serialized to the client by the global error handler.
🎯 Impact: Secrets could be exposed to unauthorized parties or leaked in client-side logs and monitoring tools.
🔧 Fix: Updated the error parameter types to `Record<string, never>` and modified the backend to stop passing sensitive data into these errors.
✅ Verification: Ran `nx test shared` (PASSED) and `npx eslint` on modified files (CLEAN). Verified file contents via `read_file`.


---
*PR created automatically by Jules for task [14170453095509651650](https://jules.google.com/task/14170453095509651650) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Prevented sensitive data (JWT tokens, license keys) from being exposed in error responses.

## Documentation

* Added security vulnerability documentation with prevention guidelines for sensitive data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->