### PR TITLE
🛡️ Sentinel: Fix information disclosure in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - [Information Disclosure in Error Parameters]
+**Vulnerability:** Sensitive data (JWT tokens, license keys) and raw system error messages (SMTP/Git errors) were being leaked in API responses through `ActivepiecesError` parameters.
+**Learning:** The global error handler in `packages/server/api/src/app/helper/error-handler.ts` serializes the `params` of `ActivepiecesError` directly to the client. Any sensitive field included in these params is exposed.
+**Prevention:** Always use `Record<string, never>` or generic error messages for errors that could contain secrets or internal system details. Audit the `params` types in `activepieces-error.ts` regularly.

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
@@ -31,7 +31,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
                 throw new ActivepiecesError({
                     code: ErrorCode.INVALID_SMTP_CREDENTIALS,
                     params: {
-                        message: JSON.stringify(e),
+                        message: 'Invalid SMTP credentials',
                     },
                 })
             }

--- a/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
@@ -40,9 +40,7 @@ export const licenseKeysController: FastifyPluginAsyncTypebox = async (app) => {
         if (isNil(key)) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_LICENSE_KEY,
-                params: {
-                    key: licenseKey,
-                },
+                params: {},
             })
         }
         await platformService.update({

--- a/packages/server/api/src/app/ee/project-release/git-sync/git-helper.ts
+++ b/packages/server/api/src/app/ee/project-release/git-sync/git-helper.ts
@@ -120,7 +120,7 @@ async function validateConnection(request: ConfigureRepoRequest): Promise<void> 
         throw new ActivepiecesError({
             code: ErrorCode.INVALID_GIT_CREDENTIALS,
             params: {
-                message: (error as Error).message,
+                message: 'Invalid git credentials',
             },
         })
     }

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<
@@ -405,9 +403,7 @@ ErrorCode.EXISTING_ALERT_CHANNEL,
 
 export type InvalidOtpParams = BaseErrorParams<ErrorCode.INVALID_OTP, Record<string, never>>
 
-export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, {
-    key: string
-}>  
+export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, Record<string, never>>
 
 export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREADY_HAS_ACTIVATION_KEY, {
     email: string


### PR DESCRIPTION
This PR addresses an information disclosure vulnerability where sensitive data was being included in `ActivepiecesError` parameters. These parameters are serialized by the global error handler and sent to the client in API responses.

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Information Disclosure
### 🎯 Impact: Sensitive tokens (JWT), license keys, and internal system error details (SMTP/Git) could be leaked to clients via API error responses.
### 🔧 Fix:
- Sanitized `InvalidJwtTokenErrorParams` and `InvalidLicenseKeyParams` by changing them to `Record<string, never>`.
- Updated all associated callers to remove sensitive arguments.
- Replaced raw exception stringification with generic "Invalid credentials" messages for SMTP and Git connection errors.
### ✅ Verification:
- Verified that `nx build shared` and `nx test shared` pass.
- Audited the code to ensure no other sensitive data is being passed to these error types.
- Manually checked modified files for correctness.

---
*PR created automatically by Jules for task [4987560341986552125](https://jules.google.com/task/4987560341986552125) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a security vulnerability where sensitive information (authentication tokens, credentials, license keys) could be exposed in API error responses.
  * Updated error handling to use generic error messages instead of detailed exception information.

* **Documentation**
  * Added security guidance regarding error payload handling to prevent future information disclosure issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->