### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize sensitive data in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-23 - Information Disclosure in Error Responses
+**Vulnerability:** API error responses were echoing sensitive data such as JWT tokens, license keys, and detailed error messages from external systems (SMTP, Git).
+**Learning:** The global error handler in `packages/server/api/src/app/helper/error-handler.ts` serializes the `params` field of `ActivepiecesError` directly to the client. Any sensitive data included in these params is disclosed.
+**Prevention:** Error parameter types in `packages/shared/src/lib/common/activepieces-error.ts` should be strictly defined and should not include sensitive fields. Use `Record<string, never>` if no safe parameters are available.

--- a/packages/react-ui/src/app/routes/platform/setup/branding/smtp-section.tsx
+++ b/packages/react-ui/src/app/routes/platform/setup/branding/smtp-section.tsx
@@ -118,7 +118,7 @@ export const SmtpSection = () => {
       if (api.isError(e)) {
         const responseData = e.response?.data as ApErrorParams;
         if (responseData.code === ErrorCode.INVALID_SMTP_CREDENTIALS) {
-          message = `Invalid SMTP credentials, please check the credentials, \n ${responseData.params.message}`;
+          message = 'Invalid SMTP credentials, please check the credentials.';
         }
       }
       form.setError('root.serverError', {

--- a/packages/react-ui/src/features/git-sync/components/connect-git-dialog.tsx
+++ b/packages/react-ui/src/features/git-sync/components/connect-git-dialog.tsx
@@ -83,7 +83,7 @@ const ConnectGitDialog = ({ open, setOpen, showButton }: ConnectGitProps) => {
       if (api.isError(error)) {
         const responseData = error.response?.data as ApErrorParams;
         if (responseData.code === ErrorCode.INVALID_GIT_CREDENTIALS) {
-          message = `Invalid git credentials, please check the credentials, \n ${responseData.params.message}`;
+          message = 'Invalid git credentials, please check the credentials.';
         }
       }
       form.setError('root.serverError', {

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
@@ -30,9 +30,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
             catch (e) {
                 throw new ActivepiecesError({
                     code: ErrorCode.INVALID_SMTP_CREDENTIALS,
-                    params: {
-                        message: JSON.stringify(e),
-                    },
+                    params: {},
                 })
             }
         },

--- a/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
@@ -40,9 +40,7 @@ export const licenseKeysController: FastifyPluginAsyncTypebox = async (app) => {
         if (isNil(key)) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_LICENSE_KEY,
-                params: {
-                    key: licenseKey,
-                },
+                params: {},
             })
         }
         await platformService.update({

--- a/packages/server/api/src/app/ee/project-release/git-sync/git-helper.ts
+++ b/packages/server/api/src/app/ee/project-release/git-sync/git-helper.ts
@@ -119,9 +119,7 @@ async function validateConnection(request: ConfigureRepoRequest): Promise<void> 
     catch (error) {
         throw new ActivepiecesError({
             code: ErrorCode.INVALID_GIT_CREDENTIALS,
-            params: {
-                message: (error as Error).message,
-            },
+            params: {},
         })
     }
     finally {

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<
@@ -405,21 +403,15 @@ ErrorCode.EXISTING_ALERT_CHANNEL,
 
 export type InvalidOtpParams = BaseErrorParams<ErrorCode.INVALID_OTP, Record<string, never>>
 
-export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, {
-    key: string
-}>  
+export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, Record<string, never>>
 
 export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREADY_HAS_ACTIVATION_KEY, {
     email: string
 }>
 
-export type InvalidSmtpCredentialsErrorParams = BaseErrorParams<ErrorCode.INVALID_SMTP_CREDENTIALS, {
-    message: string
-}>  
+export type InvalidSmtpCredentialsErrorParams = BaseErrorParams<ErrorCode.INVALID_SMTP_CREDENTIALS, Record<string, never>>
 
-export type InvalidGitCredentialsParams = BaseErrorParams<ErrorCode.INVALID_GIT_CREDENTIALS, {
-    message: string
-}>
+export type InvalidGitCredentialsParams = BaseErrorParams<ErrorCode.INVALID_GIT_CREDENTIALS, Record<string, never>>
 
 export type InvalidReleaseTypeParams = BaseErrorParams<ErrorCode.INVALID_RELEASE_TYPE, {
     message: string


### PR DESCRIPTION
This PR addresses an information disclosure vulnerability where sensitive data (JWT tokens, license keys, and detailed external system errors) were being leaked to the client via API error responses.

### 🚨 Severity: HIGH
### 💡 Vulnerability: Information Disclosure
API error responses for certain error codes included sensitive parameters that were serialized and sent to the frontend.

### 🎯 Impact:
Exposure of authentication tokens, license keys, and potentially sensitive backend system details in error messages.

### 🔧 Fix:
- Updated `ActivepiecesError` parameter types in `packages/shared` to remove sensitive fields.
- Sanitized server-side calls that throw these errors.
- Updated React UI components to handle the removal of these parameters and display generic messages.

### ✅ Verification:
- Verified type safety with `nx build shared`.
- Verified core logic with `nx test shared`.
- Manually verified UI changes via code inspection.
- Verified that sensitive data is no longer included in the error payloads.

---
*PR created automatically by Jules for task [6079997099981979368](https://jules.google.com/task/6079997099981979368) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages now display generic descriptions instead of detailed system information
  * Sensitive credentials are no longer included in error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->