### PR TITLE
🛡️ Sentinel: Fix sensitive information disclosure in error responses

### DIFF
--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -46,9 +46,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token,
-                },
+                params: {},
             })
         }
         const connection = await appConnectionService(log).getOne({
@@ -74,9 +72,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
         if (connectionName == null) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-                params: {
-                    token: request.token,
-                },
+                params: {},
             })
         }
 

--- a/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
+++ b/packages/server/api/src/app/ee/license-keys/license-keys-controller.ts
@@ -40,9 +40,7 @@ export const licenseKeysController: FastifyPluginAsyncTypebox = async (app) => {
         if (isNil(key)) {
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_LICENSE_KEY,
-                params: {
-                    key: licenseKey,
-                },
+                params: {},
             })
         }
         await platformService.update({

--- a/packages/shared/src/lib/common/activepieces-error.ts
+++ b/packages/shared/src/lib/common/activepieces-error.ts
@@ -278,9 +278,7 @@ ErrorCode.FLOW_IN_USE,
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
-{
-    token: string
-}
+Record<string, never>
 >
 
 export type TestTriggerFailedErrorParams = BaseErrorParams<
@@ -405,9 +403,7 @@ ErrorCode.EXISTING_ALERT_CHANNEL,
 
 export type InvalidOtpParams = BaseErrorParams<ErrorCode.INVALID_OTP, Record<string, never>>
 
-export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, {
-    key: string
-}>  
+export type InvalidLicenseKeyParams = BaseErrorParams<ErrorCode.INVALID_LICENSE_KEY, Record<string, never>>
 
 export type EmailAlreadyHasActivationKey = BaseErrorParams<ErrorCode.EMAIL_ALREADY_HAS_ACTIVATION_KEY, {
     email: string


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Sensitive Information Disclosure
🎯 Impact: JWT tokens and license keys could be exposed in API responses or application logs if authentication or verification fails, potentially allowing attackers to gain unauthorized access.
🔧 Fix: Modified the error parameter types to exclude sensitive fields and updated the backend services to ensure these fields are no longer included when throwing 'ActivepiecesError'.
✅ Verification: Manually verified the code changes and ensured that the 'params' object passed to 'ActivepiecesError' is now empty for the identified error codes. Ran 'nx test shared' which passed.

---
*PR created automatically by Jules for task [17854395693234803587](https://jules.google.com/task/17854395693234803587) started by @AGI-Corporation*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved error responses for JWT authentication failures to exclude token values, preventing exposure of authentication credentials in error messages.
- Improved error responses for license key verification failures to exclude key values, preventing exposure of licensing credentials in error messages.
- These changes prevent sensitive information from being unnecessarily disclosed through system error responses to users and API clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AGI-Corporation/Route.X/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->